### PR TITLE
GameOver Implemented

### DIFF
--- a/source/GameOverState.hx
+++ b/source/GameOverState.hx
@@ -1,12 +1,18 @@
 package;
 
+import lime.system.System;
+import flixel.util.FlxColor;
+import flixel.ui.FlxButton;
 import flixel.FlxG;
 import flixel.FlxSubState;
 import flixel.FlxState;
 import flixel.text.FlxText;
+import flixel.FlxSprite;
 
 class GameOverState extends FlxState {
 	var endMessage:FlxText;
+	var tryAgainButton:FlxButton;
+	var exitButton:FlxButton;
 
 	public function new() {
 		super();
@@ -21,5 +27,21 @@ class GameOverState extends FlxState {
 		endMessage = new FlxText(0, 0, 0, "Game Over!", 22);
 		endMessage.screenCenter();
 		add(endMessage);
+
+		tryAgainButton = new FlxButton((FlxG.width / 2) - 80, (FlxG.height / 2) + 50, "Try Again?", tryAgain);
+		add(tryAgainButton);
+
+		exitButton = new FlxButton((FlxG.width / 2) + 10, (FlxG.height / 2) + 50, "Exit?", exit);
+		add(exitButton);
+	}
+
+	private function tryAgain() {
+		FlxG.camera.fade(FlxColor.BLACK, 0.33, false, function() {
+			FlxG.switchState(new PlayState());
+		});
+	}
+
+	private function exit() {
+		System.exit(0);
 	}
 }

--- a/source/GameOverState.hx
+++ b/source/GameOverState.hx
@@ -1,0 +1,25 @@
+package;
+
+import flixel.FlxG;
+import flixel.FlxSubState;
+import flixel.FlxState;
+import flixel.text.FlxText;
+
+class GameOverState extends FlxState {
+	var endMessage:FlxText;
+
+	public function new() {
+		super();
+	}
+
+	override public function create() {
+		#if FLX_MOUSE
+		FlxG.mouse.visible = true;
+		#end
+
+		super.create();
+		endMessage = new FlxText(0, 0, 0, "Game Over!", 22);
+		endMessage.screenCenter();
+		add(endMessage);
+	}
+}

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -1,5 +1,6 @@
 package;
 
+import flixel.util.FlxColor;
 import heropowers.HeroPowerSelectionState;
 import heropowers.Aegis;
 import heropowers.Invincible;
@@ -25,6 +26,8 @@ class PlayState extends FlxState {
 	var SECONDS_PER_DEADLY_OBSTACLE(default, never):Float = 2;
 
 	public static var heroPowerSelection:HeroPowerEnum = Aegis;
+
+	var ending:Bool = false; // Game Over condition
 
 	override public function create() {
 		super.create();
@@ -84,11 +87,26 @@ class PlayState extends FlxState {
 	override public function update(elapsed:Float) {
 		super.update(elapsed);
 
+		// End anything else from happening if the game is ready to 'end'
+		if (ending) {
+			return;
+		}
+
 		if (FlxG.keys.justPressed.P) {
 			switchToHeroPowerSelection();
 		}
 
 		FlxG.collide(player, obstacleGenerator.obstacles);
 		FlxG.overlap(player, deadlyObstacleGenerator.obstacles, DeadlyObstacle.overlapsWithPlayer);
+		// End the game if the player reaches 0 lives or health
+		if (player.health <= 0) {
+			ending = true;
+			FlxG.camera.fade(FlxColor.BLACK, 0.33, false, gameOver);
+		}
+	}
+
+	// Helper Function: End the game
+	private function gameOver() {
+		FlxG.switchState(new GameOverState());
 	}
 }

--- a/source/PlayState.hx
+++ b/source/PlayState.hx
@@ -98,15 +98,13 @@ class PlayState extends FlxState {
 
 		FlxG.collide(player, obstacleGenerator.obstacles);
 		FlxG.overlap(player, deadlyObstacleGenerator.obstacles, DeadlyObstacle.overlapsWithPlayer);
+
 		// End the game if the player reaches 0 lives or health
 		if (player.health <= 0) {
 			ending = true;
-			FlxG.camera.fade(FlxColor.BLACK, 0.33, false, gameOver);
+			FlxG.camera.fade(FlxColor.BLACK, 0.33, false, function gameOver() {
+				FlxG.switchState(new GameOverState());
+			});
 		}
-	}
-
-	// Helper Function: End the game
-	private function gameOver() {
-		FlxG.switchState(new GameOverState());
 	}
 }

--- a/source/player/Player.hx
+++ b/source/player/Player.hx
@@ -1,10 +1,8 @@
 package player;
 
-import flixel.util.FlxColor;
 import heropowers.HeroPower;
 import flixel.FlxG;
 import flixel.FlxSprite;
-import flixel.FlxObject;
 
 class Player extends FlxSprite {
 	public static var SPEEDS(default, never):Array<Int> = [0, 50, 100];
@@ -25,8 +23,10 @@ class Player extends FlxSprite {
 		jump();
 
 		if (!isOnScreen()) {
-			kill();
+			hurt(1);
+			reset(FlxG.width / 2, FlxG.height / 2);
 		}
+
 		super.update(elapsed);
 	}
 
@@ -49,13 +49,5 @@ class Player extends FlxSprite {
 
 	override function hurt(damage:Float) {
 		super.hurt(currentPower.adjustDamage(damage));
-	}
-
-	override function kill() {
-		reset(FlxG.width / 2, FlxG.height / 2);
-		// health = maxHealth; //This line resets the players health everytime kill() is called?
-		currentPower.inUse = false;
-		currentPower.usable = true;
-		health--; // Update the players lives or health
 	}
 }

--- a/source/player/Player.hx
+++ b/source/player/Player.hx
@@ -53,8 +53,9 @@ class Player extends FlxSprite {
 
 	override function kill() {
 		reset(FlxG.width / 2, FlxG.height / 2);
-		health = maxHealth;
+		// health = maxHealth; //This line resets the players health everytime kill() is called?
 		currentPower.inUse = false;
 		currentPower.usable = true;
+		health--; // Update the players lives or health
 	}
 }


### PR DESCRIPTION
Modified the Player class to update the Player health when the kill() function is called and found a 'possible' bug that prevents the Player from losing lives at all?

Modified the update() function in PlayState to fade the camera to black and call a helper function that changes the current game state to GameOverState.

Added the GameOverState class.

Here is a screenshot of the GameOver screen when the Player reaches 0 lives:
![GameOver](https://user-images.githubusercontent.com/54049687/160227995-8db0887f-f203-4179-a923-5291d548a72d.png)

